### PR TITLE
Add config for Github Actions based CI for Linux x86_64 and aarch64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build:
+    name: Build on Linux x86_64
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libboost-all-dev
+
+    - name: Build
+      run: |
+        mkdir build
+        cd build
+        cmake ..
+        make -j
+
+  build-aarch64:
+    name: Build on Linux aarch64
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Build
+      uses: uraimo/run-on-arch-action@v2
+      with:
+        arch: aarch64
+        distro: ubuntu20.04
+        githubToken: ${{ github.token }}
+        dockerRunArgs: |
+          --volume "${PWD}:/ac-diamond"
+        install: |
+          apt-get update -q -y
+          apt-get install -q -y cmake gcc g++ libboost-all-dev
+        run: |
+          cd /ac-diamond
+          mkdir build
+          cd build
+          cmake ..
+          make -j


### PR DESCRIPTION
Related to #8 
Successful runs of the two CI jobs could be seen in my fork: https://github.com/martin-g/AC-DIAMOND/actions/runs/6159730331